### PR TITLE
fix: Do not crash when nyc is run inside itself.

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ class ProcessDB {
     infos.forEach(info => {
       if (info.parent) {
         const parentInfo = infoByUid.get(info.parent)
-        if (parentInfo.children.indexOf(info.uuid) === -1) {
+        if (parentInfo && !parentInfo.children.includes(info.uuid)) {
           parentInfo.children.push(info.uuid)
         }
       }


### PR DESCRIPTION
Ref istanbuljs/nyc#1068