### PR TITLE
fix: Just use externalId from argument.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,8 @@ const defaults = {
   ppid: process.ppid,
   root: null,
   coverageFilename: null,
-  externalId: process.env.NYC_PROCESSINFO_EXTERNAL_ID || '',
+  externalId: ''
 }
-
-delete process.env.NYC_PROCESSINFO_EXTERNAL_ID
 
 class ProcessInfo {
   constructor (fields) {


### PR DESCRIPTION
Management of the environmental variable is NYC's responsibility.