### PR TITLE
fix: Remove `root` from processinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ ProcessInfo files MUST match the following structure:
   "execArgv": Array<String>,
   "cwd": path,
   "time": Number (timestamp in ms),
-  "root": "UUID of NYC process group",
   "coverageFilename": "Path to NYC coverage info for this process",
   "externalId": "The externally specified name for this process, or null",
 }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ const defaults = {
   cwd: process.cwd(),
   time: Date.now(),
   ppid: process.ppid,
-  root: null,
   coverageFilename: null,
   externalId: ''
 }

--- a/tap-snapshots/test-process-db.js-TAP.test.js
+++ b/tap-snapshots/test-process-db.js-TAP.test.js
@@ -75,7 +75,6 @@ exports[`test/process-db.js TAP readProcessInfos > undefined 1`] = `
     "cwd": "test/fixtures",
     "time": 1555110275928,
     "ppid": 60875,
-    "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
     "coverageFilename": "0f4e28ea-5b03-4677-8c0d-263e81b42f7e.json",
     "files": [
       "test/fixtures/foo.js"
@@ -94,7 +93,6 @@ exports[`test/process-db.js TAP readProcessInfos > undefined 1`] = `
     "cwd": "test/fixtures",
     "time": 1555110276283,
     "ppid": 60876,
-    "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
     "coverageFilename": "300fc62b-eaf2-4505-981b-39567e807f94.json",
     "files": [
       "test/fixtures/bar.js"
@@ -113,7 +111,6 @@ exports[`test/process-db.js TAP readProcessInfos > undefined 1`] = `
     "cwd": "test/fixtures",
     "time": 1555110276382,
     "ppid": 60876,
-    "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
     "coverageFilename": "625ef291-93c0-40b2-a869-70587f7e8fac.json",
     "externalId": "named foo",
     "files": [
@@ -132,7 +129,6 @@ exports[`test/process-db.js TAP readProcessInfos > undefined 1`] = `
     "cwd": "test/fixtures",
     "time": 1555110276750,
     "ppid": 60878,
-    "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
     "coverageFilename": "62c33964-203a-4e6a-b1ff-8a046eeb8912.json",
     "files": [
       "test/fixtures/bar.js"

--- a/tap-snapshots/test-process-info.js-TAP.test.js
+++ b/tap-snapshots/test-process-info.js-TAP.test.js
@@ -25,7 +25,6 @@ exports[`test/process-info.js TAP basic creation > undefined 1`] = `
   ],
   "uuid": "a universally unique identifier",
   "parent": null,
-  "root": null,
   "coverageFilename": null
 }
 `

--- a/test/fixtures/.nyc_output/processinfo/0f4e28ea-5b03-4677-8c0d-263e81b42f7e.json
+++ b/test/fixtures/.nyc_output/processinfo/0f4e28ea-5b03-4677-8c0d-263e81b42f7e.json
@@ -10,7 +10,6 @@
   "cwd": "test/fixtures",
   "time": 1555110275928,
   "ppid": 60875,
-  "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
   "coverageFilename": "0f4e28ea-5b03-4677-8c0d-263e81b42f7e.json",
   "files": [
     "test/fixtures/foo.js"

--- a/test/fixtures/.nyc_output/processinfo/300fc62b-eaf2-4505-981b-39567e807f94.json
+++ b/test/fixtures/.nyc_output/processinfo/300fc62b-eaf2-4505-981b-39567e807f94.json
@@ -10,7 +10,6 @@
   "cwd": "test/fixtures",
   "time": 1555110276283,
   "ppid": 60876,
-  "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
   "coverageFilename": "300fc62b-eaf2-4505-981b-39567e807f94.json",
   "files": [
     "test/fixtures/bar.js"

--- a/test/fixtures/.nyc_output/processinfo/625ef291-93c0-40b2-a869-70587f7e8fac.json
+++ b/test/fixtures/.nyc_output/processinfo/625ef291-93c0-40b2-a869-70587f7e8fac.json
@@ -10,7 +10,6 @@
   "cwd": "test/fixtures",
   "time": 1555110276382,
   "ppid": 60876,
-  "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
   "coverageFilename": "625ef291-93c0-40b2-a869-70587f7e8fac.json",
   "externalId": "named foo",
   "files": [

--- a/test/fixtures/.nyc_output/processinfo/62c33964-203a-4e6a-b1ff-8a046eeb8912.json
+++ b/test/fixtures/.nyc_output/processinfo/62c33964-203a-4e6a-b1ff-8a046eeb8912.json
@@ -10,7 +10,6 @@
   "cwd": "test/fixtures",
   "time": 1555110276750,
   "ppid": 60878,
-  "root": "de75ec1f-158d-4a45-bb19-525c293ce4bd",
   "coverageFilename": "62c33964-203a-4e6a-b1ff-8a046eeb8912.json",
   "files": [
     "test/fixtures/bar.js"


### PR DESCRIPTION
BREAKING CHANGE: The `root` field has been removed from processinfo files.

---

This is the istanbul-lib-processinfo side of istanbuljs/nyc#1078