### PR TITLE
feat: Use async where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ A representation of information about a single process.
 Pass in fields that will be printed to the processinfo file.  Several defaults
 will be provided if not specified.
 
-#### processInfo.save()
+#### async processInfo.save()
 
 Write this process info to disk.  This works by passing the ProcessInfo object
 to JSON.stringify, and writing to `${this.directory}/${this.uuid}.json`.
 
-#### processInfo.getCoverageMap(nyc)
+#### processInfo.saveSync()
+
+The synchronous version of `.save()`.
+
+#### async processInfo.getCoverageMap(nyc)
 
 Get a merged coverage map of the current process, as well as any child
 processes.  This should only be called during tree rendering, as it depends on
@@ -65,38 +69,39 @@ A list of child ProcessInfo nodes used in tree printing.
 
 The string `'nyc'`, used as the default root node in the archy tree rendering.
 
-### processDB.writeIndex()
+### async processDB.writeIndex()
 
 Create the `index.json` file in the processinfo folder, which is required for
 tree generation and expunging.
 
-WARNING: Index writing is non-atomic, and should not be performed by multiple 
+WARNING: Index writing is non-atomic, and should not be performed by multiple
+processes.
 
-### processDB.readIndex()
+### async processDB.readIndex()
 
 Read and return the contents of the `index.json` file.  If the `index.json` is
 not present or not valid, then it will attempt to generate one.
 
-### processDB.readProcessInfos()
+### async processDB.readProcessInfos()
 
 Read all the data files in the processinfo folder, and return an object mapping
 the file basename to the resulting object.  Used in tree generation.
 
-### processDB.renderTree(nyc)
+### async processDB.renderTree(nyc)
 
 Render the tree as a string using archy, suitable for printing to the terminal.
 
-### processDB.buildProcessTree()
+### async processDB.buildProcessTree()
 
 Build the hierarchical tree of nodes for tree rendering.  Populates the `nodes`
 array of this object and all `ProcessInfo` objects in the tree.
 
-### processDB.getCoverageMap(nyc)
+### async processDB.getCoverageMap(nyc)
 
 Used in tree rendering, to show the total coverage of all the processinfo files
 in the data folder.
 
-### processDB.spawn(name, file, args, options)
+### async processDB.spawn(name, file, args, options)
 
 Spawn a child process with a unique name provided by the caller.  This name is
 stored as the `externalId` property in the child process's `ProcessInfo` data,
@@ -110,18 +115,14 @@ example, instead of `processDB.spawn('foo', 'node', ['foo.js'])`, you would run
 If a process with that name already exists in the index, then it will be
 expunged.
 
-If `options.regenerateIndex` is `true`, then ProcessDB will re-write the index
-when the process is completed.
+Unlike `child_process.spawn` this function returns a Promise which resolves to
+the `ChildProcess` object.
 
 WARNING: Calling `expunge` (which this method does) will result in the index
 being out of date.  It is the caller's responsibility to call
 `processDB.writeIndex()` when all named processes are completed.
 
-### processDB.spawnSync(name, file, args, options)
-
-Sync form of `processDB.spawn()`.
-
-### processDB.expunge(name)
+### async processDB.expunge(name)
 
 If a process exists in the process info data folder with the specified name
 (ie, it had previously been run with `processDB.spawn(name, ...)`) then the

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   "dependencies": {
     "archy": "^1.0.0",
     "cross-spawn": "^7.0.0",
-    "istanbul-lib-coverage": "^3.0.0-alpha.0",
+    "istanbul-lib-coverage": "^3.0.0-alpha.1",
     "make-dir": "^3.0.0",
+    "p-map": "^3.0.0",
     "rimraf": "^3.0.0",
     "uuid": "^3.3.3"
   },

--- a/test/process-info.js
+++ b/test/process-info.js
@@ -29,7 +29,7 @@ t.test('basic creation', t => {
   t.end()
 })
 
-t.test('save', t => {
+t.test('saveSync', t => {
   const file = __dirname + '/fixtures/.nyc_output/processinfo/blerg.json'
   t.teardown(() => rimraf(file))
 
@@ -38,13 +38,27 @@ t.test('save', t => {
     uuid: 'blerg',
   })
 
-  pi.save()
+  pi.saveSync()
 
   t.match(pi, JSON.parse(fs.readFileSync(file, 'utf8')))
   t.end()
 })
 
-t.test('nyc stuff', t => {
+t.test('save', async t => {
+  const file = __dirname + '/fixtures/.nyc_output/processinfo/blerg.json'
+  t.teardown(() => rimraf(file))
+
+  const pi = new ProcessInfo({
+    directory: __dirname + '/fixtures/.nyc_output/processinfo',
+    uuid: 'blerg',
+  })
+
+  await pi.save()
+
+  t.match(pi, JSON.parse(fs.readFileSync(file, 'utf8')))
+})
+
+t.test('nyc stuff', async t => {
   const nyc = new NYC({
     tempDir: __dirname + '/fixtures/.nyc_output',
     cwd: path.resolve(__dirname + '/..'),
@@ -59,11 +73,10 @@ t.test('nyc stuff', t => {
     {nodes: [
       new ProcessInfo(JSON.parse(fs.readFileSync(child, 'utf8')))
     ]}))
-  const cm = pi.getCoverageMap(nyc)
+  const cm = await pi.getCoverageMap(nyc)
   t.matchSnapshot(cm)
-  const cm2 = pi.getCoverageMap(nyc)
+  const cm2 = await pi.getCoverageMap(nyc)
   t.match(cm2, cm)
 
   t.matchSnapshot(pi.label)
-  t.end()
 })


### PR DESCRIPTION
BREAKING CHANGE: ProcessInfo#save is now async
BREAKING CHANGE: ProcessInfo#getCoverageMap is now async
BREAKING CHANGE: ProcessDB#writeIndex is now async
BREAKING CHANGE: ProcessDB#readIndex is now async
BREAKING CHANGE: ProcessDB#readProcessInfos is now async
BREAKING CHANGE: ProcessDB#renderTree is now async
BREAKING CHANGE: ProcessDB#buildProcessTree is now async
BREAKING CHANGE: ProcessDB#getCoverageMap is now async
BREAKING CHANGE: ProcessDB#spawn now returns a Promise which resolves to
the child process object
BREAKING CHANGE: ProcessDB#spawnSync has been removed
BREAKING CHANGE: ProcessDB#expunge is now async

---

This should be the last set of breaking changes for nyc@15.  Once nyc@15 has a beta release this will be updated to use the async methods of nyc.