### PR TITLE
Bump dependency: UUID

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const uuid = require('uuid/v4')
+const { v4: uuid } = require('uuid')
 const archy = require('archy')
 const libCoverage = require('istanbul-lib-coverage')
 const {dirname, resolve} = require('path')

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "istanbul-lib-coverage": "^3.0.0-alpha.1",
     "p-map": "^3.0.0",
     "rimraf": "^3.0.0",
-    "uuid": "^3.3.3"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "standard-version": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-lib-processinfo",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A utility for managing the `processinfo` folder that NYC uses.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This module currently relies on an outdated `uuid` release. When you install this module (as a dependency from `nyc`), the following message appears on the console:

> npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.