### PR TITLE
feat: use randomUUID from Node.js instead of uuid

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const { v4: uuidv4 } = require('uuid');
+const {randomUUID} = require('crypto')
 const archy = require('archy')
 const libCoverage = require('istanbul-lib-coverage')
 const {dirname, resolve} = require('path')
@@ -50,7 +50,7 @@ class ProcessInfo {
     Object.assign(this, defaults(), fields)
 
     if (!this.uuid) {
-      this.uuid = uuidv4()
+      this.uuid = randomUUID()
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "cross-spawn": "^7.0.3",
     "istanbul-lib-coverage": "^3.2.0",
     "p-map": "^3.0.0",
-    "rimraf": "^3.0.0",
-    "uuid": "^8.3.2"
+    "rimraf": "^3.0.0"
   },
   "devDependencies": {
     "standard-version": "^7.0.0",
@@ -27,7 +26,7 @@
     "nyc": "^15.1.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=16"
   },
   "tap": {
     "check-coverage": true,


### PR DESCRIPTION
This PR removes `uuid` library from the repo, since Node.js provides randomUUID function from Node.js v15.6.0, v14.17.0. 
https://nodejs.org/api/crypto.html#cryptorandomuuidoptions

Also I upgraded required Node.js version to v16, hoping it should be fine to consumers since that version is already deprecated per https://github.com/nodejs/release#release-schedule