### PR TITLE
fix(deps)!: upgrade rimraf addressing upstream warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const {promisify} = require('util')
 /* Shallow clone so we can promisify in-place */
 const fs = { ...require('fs') }
 const {spawn} = require('cross-spawn')
-const rimraf = promisify(require('rimraf'))
+const rimraf = require('rimraf')
 const pMap = require('p-map')
 
 const _nodes = Symbol('nodes')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cross-spawn": "^7.0.3",
     "istanbul-lib-coverage": "^3.2.0",
     "p-map": "^3.0.0",
-    "rimraf": "^3.0.0",
+    "rimraf": "^4.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "nyc": "^15.1.0"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=14"
   },
   "tap": {
     "check-coverage": true,


### PR DESCRIPTION
Resolves deprecation warnings about glob, inflight, and rimraf. See istanbuljs/nyc#1563.