### PR TITLE
fix(deps): remove vulnerable dependency `uuid`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict'
-const { v4: uuidv4 } = require('uuid');
 const archy = require('archy')
 const libCoverage = require('istanbul-lib-coverage')
 const {dirname, resolve} = require('path')
@@ -50,7 +49,7 @@ class ProcessInfo {
     Object.assign(this, defaults(), fields)
 
     if (!this.uuid) {
-      this.uuid = uuidv4()
+      this.uuid = crypto.randomUUID()
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "cross-spawn": "^7.0.3",
         "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
-        "rimraf": "^6.1.3",
-        "uuid": "^8.3.2"
+        "rimraf": "^6.1.3"
       },
       "devDependencies": {
         "nyc": "^17.1.0",
@@ -5894,6 +5893,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "cross-spawn": "^7.0.3",
     "istanbul-lib-coverage": "^3.2.0",
     "p-map": "^3.0.0",
-    "rimraf": "^6.1.3",
-    "uuid": "^8.3.2"
+    "rimraf": "^6.1.3"
   },
   "devDependencies": {
     "nyc": "^17.1.0",


### PR DESCRIPTION
This PR removes vulnerable dependency `uuid` (https://github.com/advisories/GHSA-w5hq-g745-h8pq) in favor of [`crypto.randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), which is available in all supported Node.js versions.

Resolves https://github.com/istanbuljs/istanbul-lib-processinfo/issues/38.